### PR TITLE
Fix broken archived links

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -15,7 +15,7 @@ layout:
         {% for post in site.posts %}
         <tr>
           <td>
-            <a href="/{{ post.id }}"> {{ post.title }}</a>
+            <a href="{{ post.id }}"> {{ post.title }}</a>
           </td>
           <td>
             {{ post.date | date: "%B %-d, %Y" }}


### PR DESCRIPTION
This should fix the issue with the archived posts leading to the wrong location; on blog.yacs.io it looks like the issue is that the hrefs have 2 backslashes.